### PR TITLE
Add encoding marker to a utf-8 file

### DIFF
--- a/lib/snail/constants.rb
+++ b/lib/snail/constants.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 class Snail
   # based on http://www.columbia.edu/kermit/postal.html#index, which is in turn based on
   # the USPS International Mailing Manual. See also http://www.25thandclement.com/~william/USPS_ICL.html.


### PR DESCRIPTION
lib/snail/constants.rb needs an encoding header so it can load correctly under ruby 1.9.

Would you mind releasing a new gem with this change? Would be handy for my rails3+ruby1.9.2 trials.
