### PR TITLE
Capitalize 'Andorra'. Was this intentional?

### DIFF
--- a/lib/snail/constants.rb
+++ b/lib/snail/constants.rb
@@ -7,7 +7,7 @@ class Snail
     'Afghanistan',
     'Albania',
     'Algeria',
-    'andorra',
+    'Andorra',
     'Angola',
     'Anguilla',
     'Antigua and Barbuda',


### PR DESCRIPTION
Not sure if Andorra was supposed to be all lowercase (everything I can find online has it capitalized).
