### PR TITLE
Add Ireland regions

### DIFF
--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -35,6 +35,7 @@ class Snail
     :locality   => :city,
     :state      => :region,
     :province   => :region,
+    :county     => :region,
     :zip        => :postal_code,
     :zip_code   => :postal_code,
     :postcode   => :postal_code

--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -35,7 +35,6 @@ class Snail
     :locality   => :city,
     :state      => :region,
     :province   => :region,
-    :county     => :region,
     :zip        => :postal_code,
     :zip_code   => :postal_code,
     :postcode   => :postal_code

--- a/lib/snail/helpers.rb
+++ b/lib/snail/helpers.rb
@@ -98,6 +98,35 @@ class Snail
           'Armed Forces Europe' => 'AE',
           'Armed Forces Middle East' => 'AE',
           'Armed Forces Pacific' => 'AP',
+      },
+      # http://en.wikipedia.org/wiki/Counties_of_Ireland
+      # NB: only includes Replublic of Ireland, also no abbreviations
+      :ie => {
+          'Carlows' => 'Carlows',
+          "Cavan" => 'Cavan',
+          'Clare' => 'Clare',
+          'Cork' => 'Cork',
+          'Donegal' => 'Donegal',
+          'Galway' => 'Galway',
+          'Kerry' => 'Kerry',
+          'Kildare' => 'Kildare',
+          'Kilkenny' => 'Kilkenny',
+          'Laois' => 'Laois',
+          'Leitrim' => 'Leitrim',
+          'Limerick' => 'Limerick',
+          'Longford' => 'Longford',
+          'Louth' => 'Louth',
+          'Mayo' => 'Mayo',
+          'Meath' => 'Meath',
+          'Monaghan' => 'Monaghan',
+          'Offaly' => 'Offaly',
+          'Roscommon' => 'Roscommon',
+          'Sligo' => 'Sligo',
+          'Tipperary' => 'Tipperary',
+          'Waterford' => 'Waterford',
+          'Westmeath' => 'Westmeath',
+          'Wexford' => 'Wexford',
+          'Wicklow' => 'Wicklow',
       }
   }
 

--- a/test/snail_test.rb
+++ b/test/snail_test.rb
@@ -36,7 +36,6 @@ class SnailTest < ActiveSupport::TestCase
   test "aliases common region synonyms" do
     assert_equal Snail.new(:state => "Somewheres").region, Snail.new(:region => "Somewheres").region
     assert_equal Snail.new(:province => "Somewheres").region, Snail.new(:region => "Somewheres").region
-    assert_equal Snail.new(:county => "Somewheres").region, Snail.new(:region => "Somewheres").region
   end
 
   test "aliases common postal code synonyms" do

--- a/test/snail_test.rb
+++ b/test/snail_test.rb
@@ -4,12 +4,14 @@ class SnailTest < ActiveSupport::TestCase
   def setup
     @us = {:name => "John Doe", :line_1 => "12345 5th St", :city => "Somewheres", :state => "NY", :zip => "12345", :country => 'USA'}
     @ca = {:name => "John Doe", :line_1 => "12345 5th St", :city => "Somewheres", :state => "NY", :zip => "12345", :country => 'CAN'}
+    @ie = {:name => "John Doe", :line_1 => "12345 5th St", :city => "Somewheres", :region => "Dublin", :zip => "12345", :country => 'IE'}
   end
 
   test "provides region codes via 2-digit iso country code" do
     assert_equal "WA", Snail::REGIONS[:us]["Washington"]
     assert_equal "WA", Snail::REGIONS[:au]["Western Australia"]
     assert_equal "BC", Snail::REGIONS[:ca]["British Columbia"]
+    assert_equal "Cork", Snail::REGIONS[:ie]["Cork"]
   end
 
   ##
@@ -34,6 +36,7 @@ class SnailTest < ActiveSupport::TestCase
   test "aliases common region synonyms" do
     assert_equal Snail.new(:state => "Somewheres").region, Snail.new(:region => "Somewheres").region
     assert_equal Snail.new(:province => "Somewheres").region, Snail.new(:region => "Somewheres").region
+    assert_equal Snail.new(:county => "Somewheres").region, Snail.new(:region => "Somewheres").region
   end
 
   test "aliases common postal code synonyms" do


### PR DESCRIPTION
Enumerating the regions for Ireland.  They aren't typically abbreviated, so string names are just mapped to string names in the `REGIONS` hash.

Also including `county` as a synonym for region since that's how Ireland does it.