### PR TITLE
Allow the country_line to be always displayed. Fixes #28.

### DIFF
--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -89,16 +89,16 @@ class Snail
     @origin ||= Snail.home_country
   end
 
-  def to_s(country: false)
+  def to_s(with_country: false)
     address_lines = [name, line_1, line_2, city_line]
-    if country || (@country && self.origin != @country)
+    if with_country || (country && self.origin != country)
       address_lines.push(country_line)
     end
     address_lines.select{|line| !(line.nil? or line.empty?)}.join("\n")
   end
 
-  def to_html(country: false)
-    CGI.escapeHTML(to_s(country: country)).gsub("\n", '<br />').html_safe
+  def to_html(with_country: false)
+    CGI.escapeHTML(to_s(with_country: with_country)).gsub("\n", '<br />').html_safe
   end
 
   # this method will get much larger. completeness is out of my scope at this time.

--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -89,15 +89,15 @@ class Snail
     @origin ||= Snail.home_country
   end
 
-  def to_s(with_country: false)
+  def to_s(with_country: nil)
     address_lines = [name, line_1, line_2, city_line]
-    if with_country || (country && self.origin != country)
+    if with_country || (with_country.nil? && country && self.origin != country)
       address_lines.push(country_line)
     end
     address_lines.select{|line| !(line.nil? or line.empty?)}.join("\n")
   end
 
-  def to_html(with_country: false)
+  def to_html(with_country: nil)
     CGI.escapeHTML(to_s(with_country: with_country)).gsub("\n", '<br />').html_safe
   end
 

--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -89,12 +89,16 @@ class Snail
     @origin ||= Snail.home_country
   end
 
-  def to_s
-    [name, line_1, line_2, city_line, country_line].select{|line| !(line.nil? or line.empty?)}.join("\n")
+  def to_s(country: false)
+    address_lines = [name, line_1, line_2, city_line]
+    if country || (@country && self.origin != @country)
+      address_lines.push(country_line)
+    end
+    address_lines.select{|line| !(line.nil? or line.empty?)}.join("\n")
   end
 
-  def to_html
-    CGI.escapeHTML(to_s).gsub("\n", '<br />').html_safe
+  def to_html(country: false)
+    CGI.escapeHTML(to_s(country: country)).gsub("\n", '<br />').html_safe
   end
 
   # this method will get much larger. completeness is out of my scope at this time.
@@ -150,9 +154,7 @@ class Snail
   end
 
   def country_line
-    if country and self.origin != country
-      (translated_country(self.origin, country) || translated_country("US", country))
-    end
+    (translated_country(self.origin, @country) || translated_country("US", @country))
   end
 
   def translated_country(origin, country)

--- a/test/snail_test.rb
+++ b/test/snail_test.rb
@@ -72,7 +72,7 @@ class SnailTest < Snail::TestCase
     assert s.city_line.match(/NY  12345/)
   end
 
-  test "does not include country name for domestic addresses" do
+  test "does not include country name for domestic addresses by default" do
     s = Snail.new(@us.merge(:origin => 'US'))
     assert !s.to_s.match(/United States/i)
     s = Snail.new(@ca.merge(:origin => 'CA'))
@@ -86,7 +86,14 @@ class SnailTest < Snail::TestCase
     assert s.to_s(with_country: true).match(/Canada/i)
   end
 
-  test "includes country name for international addresses" do
+  test "does not include country name for domestic addresses if with_country parameter is false" do
+    s = Snail.new(@us.merge(:origin => 'US'))
+    assert !s.to_s(with_country: false).match(/United States/i)
+    s = Snail.new(@ca.merge(:origin => 'CA'))
+    assert !s.to_s(with_country: false).match(/Canada/i)
+  end
+
+  test "includes country name for international addresses by default" do
     s = Snail.new(@us.merge(:origin => 'CA'))
     assert s.to_s.match(/United States/i)
     s = Snail.new(@ca.merge(:origin => 'US'))
@@ -99,10 +106,12 @@ class SnailTest < Snail::TestCase
     s = Snail.new(@ca.merge(:origin => 'US'))
     assert s.to_s(with_country: true).match(/Canada/i)
   end
+
+  test "does not include country name for international addresses if with_country parameter is false" do
     s = Snail.new(@us.merge(:origin => 'CA'))
-    assert s.to_s(country: true).match(/United States/i)
+    assert !s.to_s(with_country: false).match(/United States/i)
     s = Snail.new(@ca.merge(:origin => 'US'))
-    assert s.to_s(country: true).match(/Canada/i)
+    assert !s.to_s(with_country: false).match(/Canada/i)
   end
 
   test "includes translated country name for international addresses" do

--- a/test/snail_test.rb
+++ b/test/snail_test.rb
@@ -79,11 +79,25 @@ class SnailTest < Snail::TestCase
     assert !s.to_s.match(/Canada/i)
   end
 
+  test "includes country name for domestic addresses if the country parameter is present" do
+    s = Snail.new(@us.merge(:origin => 'US'))
+    assert s.to_s(country: true).match(/United States/i)
+    s = Snail.new(@ca.merge(:origin => 'CA'))
+    assert s.to_s(country: true).match(/Canada/i)
+  end
+
   test "includes country name for international addresses" do
     s = Snail.new(@us.merge(:origin => 'CA'))
     assert s.to_s.match(/United States/i)
     s = Snail.new(@ca.merge(:origin => 'US'))
     assert s.to_s.match(/Canada/i)
+  end
+
+  test "includes country name for international addresses if the country parameter is present" do
+    s = Snail.new(@us.merge(:origin => 'CA'))
+    assert s.to_s(country: true).match(/United States/i)
+    s = Snail.new(@ca.merge(:origin => 'US'))
+    assert s.to_s(country: true).match(/Canada/i)
   end
 
   test "includes translated country name for international addresses" do

--- a/test/snail_test.rb
+++ b/test/snail_test.rb
@@ -79,11 +79,11 @@ class SnailTest < Snail::TestCase
     assert !s.to_s.match(/Canada/i)
   end
 
-  test "includes country name for domestic addresses if the country parameter is present" do
+  test "includes country name for domestic addresses if with_country parameter is true" do
     s = Snail.new(@us.merge(:origin => 'US'))
-    assert s.to_s(country: true).match(/United States/i)
+    assert s.to_s(with_country: true).match(/United States/i)
     s = Snail.new(@ca.merge(:origin => 'CA'))
-    assert s.to_s(country: true).match(/Canada/i)
+    assert s.to_s(with_country: true).match(/Canada/i)
   end
 
   test "includes country name for international addresses" do
@@ -93,7 +93,12 @@ class SnailTest < Snail::TestCase
     assert s.to_s.match(/Canada/i)
   end
 
-  test "includes country name for international addresses if the country parameter is present" do
+  test "includes country name for international addresses if with_country parameter is true" do
+    s = Snail.new(@us.merge(:origin => 'CA'))
+    assert s.to_s(with_country: true).match(/United States/i)
+    s = Snail.new(@ca.merge(:origin => 'US'))
+    assert s.to_s(with_country: true).match(/Canada/i)
+  end
     s = Snail.new(@us.merge(:origin => 'CA'))
     assert s.to_s(country: true).match(/United States/i)
     s = Snail.new(@ca.merge(:origin => 'US'))


### PR DESCRIPTION
Here is my attempt to fix #28. This PR ensures full backward compatibility (except for `Snail#country_line`).

The only thing that I am not really happy with is the naming of the optional parameter. The code is slightly more complex because of `country`, the optional parameter, and `@country`, the value. `force_country`  might be better. What do you think?