### PR TITLE
falls back to english if country not translated

### DIFF
--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -22,10 +22,12 @@ class Snail
   attr_accessor :region
   attr_accessor :postal_code
   attr_reader   :country
+  attr_reader   :country_iso
 
   # Store country as ISO-3166 Alpha 2
   def country=(val)
-    @country = Snail.lookup_country_iso(val)
+    @country = val
+    @country_iso = Snail.lookup_country_iso(val)
   end
 
   # Aliases for easier assignment compatibility
@@ -90,7 +92,7 @@ class Snail
   end
 
   def international?
-    country && self.origin != country
+    country_iso && self.origin != country_iso
   end
 
   def to_s(with_country: nil)
@@ -112,7 +114,7 @@ class Snail
   # this method will get much larger. completeness is out of my scope at this time.
   # currently it's based on the sampling of city line formats from frank's compulsive guide.
   def city_line
-    case country
+    case country_iso
     when 'CN', 'IN'
       "#{city}, #{region}  #{postal_code}"
     when 'BR'
@@ -162,11 +164,14 @@ class Snail
   end
 
   def country_line
-    (translated_country(self.origin, @country) || translated_country("US", @country))
+    return country if country_iso.nil? 
+    (translated_country(self.origin, country_iso) || translated_country("US", country_iso))
   end
 
   def translated_country(origin, country)
     path = File.join(File.dirname(File.expand_path(__FILE__)), "../assets/#{origin}.yml")
-    File.read(path).match(/^#{country}: (.*)$/)[1]
+    matches = File.read(path).match(/^#{country}: (.*)$/)
+    return nil if matches.nil?
+    matches[1]
   end
 end

--- a/test/snail_test.rb
+++ b/test/snail_test.rb
@@ -50,17 +50,17 @@ class SnailTest < Snail::TestCase
 
   test "normalize alpha3 to alpha2" do
     s = Snail.new(@ca.merge(:country => 'SVN'))
-    assert_equal "SI", s.country
+    assert_equal "SI", s.country_iso
   end
 
   test "normalize alpha2 exceptions to alpha2" do
     s = Snail.new(@ca.merge(:country => 'UK'))
-    assert_equal "GB", s.country
+    assert_equal "GB", s.country_iso
   end
 
   test "leave alpha2 as alpha2" do
     s = Snail.new(@ca.merge(:country => 'GB'))
-    assert_equal "GB", s.country
+    assert_equal "GB", s.country_iso
   end
 
   ##
@@ -119,6 +119,16 @@ class SnailTest < Snail::TestCase
     assert s.to_s.match(/ÉTATS-UNIS/i)
     s = Snail.new(@ca.merge(:origin => 'EC'))
     assert s.to_s.match(/CANADÁ/i)
+  end
+
+  test "falls back to english if the country name is not translated in the origin country langage" do
+    s = Snail.new({:name => "John Doe", :line_1 => "12345 5th St", :city => "Somewheres", :state => "NY", :zip => "12345", :country => 'IE', :origin => 'AF'})
+    assert s.to_s(with_country: true).match(/IRELAND/i)
+  end
+
+  test "includes the raw country if it is not a valid iso code" do
+    s = Snail.new({:name => "John Doe", :line_1 => "12345 5th St", :city => "Somewheres", :state => "NY", :zip => "12345", :country => 'United States'})
+    assert s.to_s(with_country: true).match(/United States/)
   end
 
   test "includes first country name for countries with many commonly used names" do


### PR DESCRIPTION
hi @cainlevy,

In some rare cases, the translation might not be present (thinking about AF for instance). The fallback
code to english was broken due to the `match` function. Also, if a country is not a valid
iso code, we should display the raw value.