### PR TITLE
update ireland to include postal code

### DIFF
--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -132,7 +132,7 @@ class Snail
     when 'NL'
       "#{postal_code}  #{city}"
     when 'IE'
-      "#{city}, #{region}"
+      "#{city}, #{region}\n#{postal_code}"
     when 'GB', 'RU', 'UA', 'JO', 'LB', 'IR', 'SA', 'NZ'
       "#{city}  #{postal_code}" # Locally these may be on separate lines. The USPS prefers the city line above the country line, though.
     when 'EC'

--- a/lib/snail.rb
+++ b/lib/snail.rb
@@ -132,7 +132,7 @@ class Snail
     when 'NL'
       "#{postal_code}  #{city}"
     when 'IE'
-      "#{city}, #{region}\n#{postal_code}"
+      "#{city}, #{region}#{"\n" unless postal_code.nil? || postal_code.empty?}#{postal_code}"
     when 'GB', 'RU', 'UA', 'JO', 'LB', 'IR', 'SA', 'NZ'
       "#{city}  #{postal_code}" # Locally these may be on separate lines. The USPS prefers the city line above the country line, though.
     when 'EC'

--- a/test/snail_test.rb
+++ b/test/snail_test.rb
@@ -146,11 +146,23 @@ class SnailTest < Snail::TestCase
     assert_equal "John Doe\n12345 5th St\nSomewheres NY  12345\nCANADA", s.to_s
   end
 
+  test "to_s ireland doesn't show a linebreak if zip is empty" do
+    s = Snail.new(@ie.merge(:zip => ""))
+    puts s.to_s
+    assert_equal "John Doe\n12345 5th St\nSomewheres, Dublin\nIRELAND", s.to_s
+  end
+
   test "to_html" do
     s = Snail.new(@ca)
     s.name = 'John & Jane Doe'
     assert_equal "John &amp; Jane Doe<br />12345 5th St<br />Somewheres NY  12345<br />CANADA", s.to_html
     assert s.to_html.html_safe?
+  end
+
+  test "to_html ireland doesn't show a linebreak if zip is empty" do
+    s = Snail.new(@ie.merge(:zip => ""))
+    s.name = 'John & Jane Doe'
+    assert_equal "John &amp; Jane Doe<br />12345 5th St<br />Somewheres, Dublin<br />IRELAND", s.to_html
   end
 end
 


### PR DESCRIPTION
http://www.eircode.ie/faqs#UsingAnEircode

![image](https://cloud.githubusercontent.com/assets/9433365/16924284/804d5b06-4cec-11e6-9600-e34a07301f12.png)

looks like we should now be showing ireland postal codes if they're available. 

this is also ~ noted ~ in the compulsive's ireland section:

http://www.columbia.edu/~fdc/postal/#ireland